### PR TITLE
Revert "dont expose micro services to exterior"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,14 @@ services:
     build: ./users-api
     volumes:
       - ./users-api/src:/users-api/src
+    ports:
+      - "3000:3000"
   match:
     build: ./match-api
     volumes:
       - ./match-api/src:/match-api/src
+    ports:
+      - "3100:3100"
     depends_on:
       - user
   proxy:


### PR DESCRIPTION
To make the apps work as it seems match-api service can not communicate with user-api one with by passing through the proxy

This reverts commit cc050e1f98a031486ff3795b2bcb6da62603960a.